### PR TITLE
Use functions from newer primitive and primitive-unlifted

### DIFF
--- a/contiguous.cabal
+++ b/contiguous.cabal
@@ -38,7 +38,7 @@ library
   build-depends:
     , base                >=4.14    && <5
     , deepseq             >=1.4
-    , primitive           >=0.7.2   && <0.10
+    , primitive           >=0.9     && <0.10
     , primitive-unlifted  >=2.1
     , run-st              >=0.1.3.2
 

--- a/src/Data/Primitive/Contiguous.hs
+++ b/src/Data/Primitive/Contiguous.hs
@@ -273,7 +273,7 @@ module Data.Primitive.Contiguous
   ) where
 
 import Control.Monad.Primitive
-import Data.Primitive hiding (fromList, fromListN)
+import Data.Primitive
 import Data.Primitive.Unlifted.Array
 import Prelude hiding (Foldable (..), all, any, filter, map, mapM, mapM_, read, replicate, reverse, scanl, sequence, sequence_, traverse, zip, zipWith, (<$))
 

--- a/src/Data/Primitive/Contiguous/Class.hs
+++ b/src/Data/Primitive/Contiguous/Class.hs
@@ -1273,7 +1273,7 @@ instance Contiguous (UnliftedArray_ unlifted_a) where
 -- Note [Shrinking Arrays Without a Shrink Primop]
 -- ===============================================
 -- GHC's Array# type has a card table and cannot currently be shrunk in place.
--- (SmallArray#, however, can be shrunk in place). These implementations copy
+-- (SmallArray#, however, can be shrunk in place.) These implementations copy
 -- the array rather than freezing it in place. But at least they are able to
 -- avoid assigning all of the elements to a nonsense value before replacing
 -- them with memcpy.

--- a/src/Data/Primitive/Contiguous/Class.hs
+++ b/src/Data/Primitive/Contiguous/Class.hs
@@ -866,6 +866,7 @@ instance Contiguous SmallArray where
   shrink !arr !n = do
     shrinkSmallMutableArray arr n
     pure arr
+  {-# INLINE unsafeShrinkAndFreeze #-}
   unsafeShrinkAndFreeze !arr !n = do
     shrinkSmallMutableArray arr n
     unsafeFreezeSmallArray arr

--- a/src/Data/Primitive/Contiguous/Class.hs
+++ b/src/Data/Primitive/Contiguous/Class.hs
@@ -572,7 +572,7 @@ class (Contiguous arr) => ContiguousU arr where
   -- | Resize an array into one with the given size. If the array is grown,
   -- then reading from any newly introduced element before writing to it is undefined behavior.
   -- The current behavior is that anything backed by @MutableByteArray#@ ends
-  -- uninitialized memory at these indices. But for @SmallMutableArray@, these
+  -- uninitialized memory at these indices. But for @SmallMutableArray@ or @Array@, these
   -- are set to an error thunk, so reading from them and forcing the result
   -- causes the program to crash.
   resize ::

--- a/src/Data/Primitive/Contiguous/Class.hs
+++ b/src/Data/Primitive/Contiguous/Class.hs
@@ -574,7 +574,7 @@ class (Contiguous arr) => ContiguousU arr where
   -- The current behavior is that anything backed by @MutableByteArray#@ ends
   -- uninitialized memory at these indices. But for @SmallMutableArray@ or @Array@, these
   -- are set to an error thunk, so reading from them and forcing the result
-  -- causes the program to crash.
+  -- causes the program to crash. For @UnliftedArray@, the new elements have undefined values of an unknown type.
   resize ::
     (PrimMonad m, Element arr b) =>
     Mutable arr (PrimState m) b ->

--- a/src/Data/Primitive/Contiguous/Class.hs
+++ b/src/Data/Primitive/Contiguous/Class.hs
@@ -139,7 +139,7 @@ class Contiguous (arr :: Type -> Type) where
     b -> -- fill element
     m (Mutable arr (PrimState m) b)
 
-  -- | Resize an array without growing it.
+  -- | Resize an array without growing it. It may be shrunk in place.
   --
   -- @since 0.6.0
   shrink ::

--- a/src/Data/Primitive/Contiguous/Class.hs
+++ b/src/Data/Primitive/Contiguous/Class.hs
@@ -548,7 +548,7 @@ class (Contiguous arr) => ContiguousU arr where
 
   -- | Resize an array into one with the given size. If the array is grown,
   -- then reading from any newly introduced element before writing to it is undefined behavior.
-  -- The current behavior is that anything backed by @MutableByteArray#@ ends
+  -- The current behavior is that anything backed by @MutableByteArray#@ ends with
   -- uninitialized memory at these indices. But for @SmallMutableArray@ or @Array@, these
   -- are set to an error thunk, so reading from them and forcing the result
   -- causes the program to crash. For @UnliftedArray@, the new elements have undefined values of an unknown type.

--- a/src/Data/Primitive/Contiguous/Class.hs
+++ b/src/Data/Primitive/Contiguous/Class.hs
@@ -575,6 +575,7 @@ class (Contiguous arr) => ContiguousU arr where
   -- uninitialized memory at these indices. But for @SmallMutableArray@ or @Array@, these
   -- are set to an error thunk, so reading from them and forcing the result
   -- causes the program to crash. For @UnliftedArray@, the new elements have undefined values of an unknown type.
+  -- If the array is not grown, it may (or may not) be modified in place.
   resize ::
     (PrimMonad m, Element arr b) =>
     Mutable arr (PrimState m) b ->

--- a/src/Data/Primitive/Contiguous/Shim.hs
+++ b/src/Data/Primitive/Contiguous/Shim.hs
@@ -27,7 +27,7 @@ resizeArray !src !sz = do
     LT -> cloneMutableArray src 0 sz
     GT -> do
       dst <- newArray sz errorThunk
-      copyMutableArray dst 0 src 0 sz
+      copyMutableArray dst 0 src 0 srcSz
       pure dst
 {-# INLINE resizeArray #-}
 

--- a/src/Data/Primitive/Contiguous/Shim.hs
+++ b/src/Data/Primitive/Contiguous/Shim.hs
@@ -4,18 +4,12 @@
 module Data.Primitive.Contiguous.Shim
   ( errorThunk
   , resizeArray
-  , resizeSmallArray
-  , replicateSmallMutableArray
   , resizeUnliftedArray
   , replicateMutablePrimArray
-  , clonePrimArrayShim
-  , cloneMutablePrimArrayShim
-  , freezePrimArrayShim
   ) where
 
 import Control.Monad (when)
-import Control.Monad.ST.Run (runPrimArrayST)
-import Data.Primitive hiding (fromList, fromListN)
+import Data.Primitive
 import Data.Primitive.Unlifted.Array
 import Prelude hiding (all, any, elem, filter, foldMap, foldl, foldr, map, mapM, mapM_, maximum, minimum, null, read, replicate, reverse, scanl, sequence, sequence_, traverse, zip, zipWith, (<$))
 
@@ -33,32 +27,16 @@ resizeArray !src !sz = do
   pure dst
 {-# INLINE resizeArray #-}
 
-resizeSmallArray :: (PrimMonad m) => SmallMutableArray (PrimState m) a -> Int -> m (SmallMutableArray (PrimState m) a)
-resizeSmallArray !src !sz = do
-  dst <- newSmallArray sz errorThunk
-  copySmallMutableArray dst 0 src 0 (min sz (sizeofSmallMutableArray src))
-  pure dst
-{-# INLINE resizeSmallArray #-}
-
-replicateSmallMutableArray ::
-  (PrimMonad m) =>
-  Int ->
-  a ->
-  m (SmallMutableArray (PrimState m) a)
-replicateSmallMutableArray len a = do
-  marr <- newSmallArray len errorThunk
-  let go !ix = when (ix < len) $ do
-        writeSmallArray marr ix a
-        go (ix + 1)
-  go 0
-  pure marr
-{-# INLINE replicateSmallMutableArray #-}
-
 resizeUnliftedArray :: (PrimMonad m, PrimUnlifted a) => MutableUnliftedArray (PrimState m) a -> Int -> m (MutableUnliftedArray (PrimState m) a)
-resizeUnliftedArray !src !sz = do
-  dst <- unsafeNewUnliftedArray sz
-  copyMutableUnliftedArray dst 0 src 0 (min sz (sizeofMutableUnliftedArray src))
-  pure dst
+resizeUnliftedArray !src !sz =
+  let !srcSz = sizeofMutableUnliftedArray src in
+  case compare sz srcSz of
+    EQ -> pure src
+    LT -> cloneMutableUnliftedArray src 0 sz
+    GT -> do
+      dst <- unsafeNewUnliftedArray sz
+      copyMutableUnliftedArray dst 0 src 0 (min sz (sizeofMutableUnliftedArray src))
+      pure dst
 {-# INLINE resizeUnliftedArray #-}
 
 replicateMutablePrimArray ::
@@ -73,24 +51,3 @@ replicateMutablePrimArray len a = do
   setPrimArray marr 0 len a
   pure marr
 {-# INLINE replicateMutablePrimArray #-}
-
-clonePrimArrayShim :: (Prim a) => PrimArray a -> Int -> Int -> PrimArray a
-clonePrimArrayShim !arr !off !len = runPrimArrayST $ do
-  marr <- newPrimArray len
-  copyPrimArray marr 0 arr off len
-  unsafeFreezePrimArray marr
-{-# INLINE clonePrimArrayShim #-}
-
-cloneMutablePrimArrayShim :: (PrimMonad m, Prim a) => MutablePrimArray (PrimState m) a -> Int -> Int -> m (MutablePrimArray (PrimState m) a)
-cloneMutablePrimArrayShim !arr !off !len = do
-  marr <- newPrimArray len
-  copyMutablePrimArray marr 0 arr off len
-  pure marr
-{-# INLINE cloneMutablePrimArrayShim #-}
-
-freezePrimArrayShim :: (PrimMonad m, Prim a) => MutablePrimArray (PrimState m) a -> Int -> Int -> m (PrimArray a)
-freezePrimArrayShim !src !off !len = do
-  dst <- newPrimArray len
-  copyMutablePrimArray dst 0 src off len
-  unsafeFreezePrimArray dst
-{-# INLINE freezePrimArrayShim #-}

--- a/src/Data/Primitive/Contiguous/Shim.hs
+++ b/src/Data/Primitive/Contiguous/Shim.hs
@@ -39,7 +39,7 @@ resizeUnliftedArray !src !sz = do
     LT -> cloneMutableUnliftedArray src 0 sz
     GT -> do
       dst <- unsafeNewUnliftedArray sz
-      copyMutableUnliftedArray dst 0 src 0 sz
+      copyMutableUnliftedArray dst 0 src 0 srcSz
       pure dst
 {-# INLINE resizeUnliftedArray #-}
 


### PR DESCRIPTION
The implementation UnliftedArray in primitive-unlifted-2.1 penalizes the creation of an uninitialized unlifted array. When shrinking and resizing unlifted arrays, there are primitives that we can use to avoid this.

Also, primitive itself now has shims for common operations on PrimArray, so this commit also cleans up the Shim module.